### PR TITLE
Pass verbose argument to calculate.crossfit.models

### DIFF
--- a/R/functions.R
+++ b/R/functions.R
@@ -121,7 +121,7 @@ scde.error.models <- function(counts, groups = NULL, min.nonfailed = 3, threshol
     if(verbose) {
         cat("cross-fitting cells.\n")
     }
-    cfm <- calculate.crossfit.models(counts, groups, n.cores = n.cores, threshold.segmentation = threshold.segmentation, min.count.threshold = min.count.threshold, zero.lambda = zero.lambda, max.pairs = max.pairs, save.plots = save.crossfit.plots, min.pairs.per.cell = min.pairs.per.cell)
+    cfm <- calculate.crossfit.models(counts, groups, n.cores = n.cores, threshold.segmentation = threshold.segmentation, min.count.threshold = min.count.threshold, zero.lambda = zero.lambda, max.pairs = max.pairs, save.plots = save.crossfit.plots, min.pairs.per.cell = min.pairs.per.cell, verbose = verbose)
     # error model for each cell
     if(verbose) {
         cat("building individual error models.\n")


### PR DESCRIPTION
`scde.error.models` function should propagate verbosity to other functions such as `calculate.crossfit.models`. Actually for the readability purposes, it would be better to split arguments into multiple lines and to align them.