### PR TITLE
Pin flexmix to 2.3-13.

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -31,7 +31,7 @@ URL: http://pklab.med.harvard.edu/scde
 BugReports: https://github.com/hms-dbmi/scde/issues
 License: GPL-2
 LazyData: true
-Depends: R (>= 3.0.0), flexmix
+Depends: R (>= 3.0.0), flexmix (<= 2.3-13)
 Imports: Rcpp (>= 0.10.4), RcppArmadillo (>= 0.5.400.2.0), mgcv, Rook,
         rjson, MASS, Cairo, RColorBrewer, edgeR, quantreg, methods,
         nnet, RMTstat, extRemes, pcaMethods, BiocParallel, parallel,


### PR DESCRIPTION
This PR pins flexmix to version 2.3-13. This way if a user installs scde via GitHub, they won't experience the known errors caused by changes introduced in flexmix 2.3.-14.



xref: #40 #48 and [Google Group discussion](https://hms-dbmi.github.io/scde/help.html?place=msg%2Fsinglecellstats%2FrbFUTOQ9wu4%2Fyg4cxLbeAAAJ)